### PR TITLE
Fix tutorial on colab

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +78,7 @@
     "    from google.colab import drive\n",
     "    drive.mount('/content/drive')\n",
     "    import os\n",
-    "    os.chdir('dimelo_v2')   \n",
+    "    os.chdir('dimelo')   \n",
     "except:\n",
     "    pass"
    ]


### PR DESCRIPTION
Removed reference to v2 which silently prevented completion of the tutorial notebook on Google colab.