### PR TITLE
Pre submission updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,27 +51,27 @@ This README document contains installation instructions and documentation for va
 
 **Platforms:** Mac and Linux operating systems, ARM (e.g. M1/M2 mac) and x86 (e.g. Intel mac) architectures. The package has been tested on HPC clusters, but there may be additional complexities depending on how these systems are set up.
 
-*For Windows,  we recommend using [Google Colab](https://colab.research.google.com/). We have not tested on [Windows Linux Subsystem](https://learn.microsoft.com/en-us/windows/wsl/install) but in principle that should work too. Windows support is possible in future, but blocked by [conda availability for modkit executables](https://anaconda.org/nanoporetech/modkit) and the [current implementation](dimelo/run_modkit.py) of live error/progress tracking during modkit execution, which relies on a unix-only library as of Python 3.11. The urgency of a Windows implementation will depend on user need, so please let us know if this is important for you.*
+*For Windows,  we recommend using [Google Colab](https://colab.research.google.com/). We have not tested on [Windows Linux Subsystem](https://learn.microsoft.com/en-us/windows/wsl/install) but in principle that should work too. Windows support is possible in future, but blocked by [conda availability for modkit executables](https://anaconda.org/nanoporetech/modkit) and the [current implementation](dimelo-toolkit/run_modkit.py) of live error/progress tracking during modkit execution, which relies on a unix-only library as of Python 3.11. The urgency of a Windows implementation will depend on user need, so please let us know if this is important for you.*
 
 **Conda and Python:** The default installation requires conda, or alternatives like mamba. See [here](https://www.anaconda.com/download) for conda installation. The installation instructions below will install Python 3.11 for you within a conda virtual environment, but depending on your system configuration you may need to ensure that you are not also loading a different version of Python on your path. If you encounter unexpected errors when importing `dimelo`, e.g. complaining about syntax, consider checking your Python version.
 
-### Load source code from the modkit_parsing_beta branch
+### Load source code for dimelo-toolkit
 
-Open your terminal or command line and navigate to wherever you want to keep the `dimelo` source code (e.g. your Documents folder, `cd Documents`) and clone the repo
+Open your terminal or command line and navigate to wherever you want to keep the `dimelo-toolkit` source code (e.g. your Documents folder, `cd Documents`) and clone the repo
 
 ```
-git clone https://github.com/streetslab/dimelo
+git clone https://github.com/streetslab/dimelo-toolkit
 ```
 
 ### Set up virtual environment
 
-Navigate into the dimelo directory
+Navigate into the dimelo-toolkit directory
 
 ```
-cd dimelo
+cd dimelo-toolkit
 ```
 
-Create a conda environment using environment.yml. This will make a new conda environment with the name `dimelo`. 
+Create a conda environment using environment.yml. This will make a new conda environment with the name `dimelo-toolkit`. 
 
 ```
 conda env create -f environment.yml
@@ -79,15 +79,15 @@ conda env create -f environment.yml
 
 *If you want to handle environment creation yourself, see [the alternative installation instructions](#alternative-installations).*
 
-### Install pip dependencies and core dimelo package
+### Install pip dependencies and core dimelo-toolkit package
 
 Activate your conda environment, which should now contain python 3.11 and a modkit executable on the path and executable on your system.
 
 ```
-conda activate dimelo
+conda activate dimelo-toolkit
 ```
 
-Ensure that you are still in the top-level dimelo directory. Install the dimelo package and its dependencies from source.
+Ensure that you are still in the top-level dimelo-toolkit directory. Install the dimelo-toolkit package and its dependencies from source.
 
 ```
 pip install .
@@ -95,7 +95,7 @@ pip install .
 
 ## Google Colab Installation
 
-Run the following code in the first cell of your notebook to grab `modkit v0.2.4` from conda and install the `dimelo modkit_parsing_beta` branch. This will have to be run whenever you make a new Colab instance, unless you have a better way of managing this, in which case please reach out. The tutorial notebook runs equivalent code blocks to set up your environment, so if you are trying to run the tutorial you can skip to [Basic Use](#basic-use).
+Run the following code in the first cell of your notebook to grab `modkit v0.2.4` from conda and install the `dimelo-toolkit main` branch. This will have to be run whenever you make a new Colab instance, unless you have a better way of managing this, in which case please reach out. The tutorial notebook runs equivalent code blocks to set up your environment, so if you are trying to run the tutorial you can skip to [Basic Use](#basic-use).
 
 ```
 from google.colab import drive
@@ -104,14 +104,14 @@ drive.mount('/content/drive')
 import condacolab
 condacolab.install()
 !conda install nanoporetech::modkit==0.2.4
-!git clone https://github.com/streetslab/dimelo
-!cd dimelo && pip install ipywidgets==7.7.1 .
+!git clone https://github.com/streetslab/dimelo-toolkit
+!cd dimelo-toolkit && pip install ipywidgets==7.7.1 .
 import dimelo
 ```
 
 ## Alternative Installations
 
-Alternatively, you can install modkit into any conda environment you like. If you want to, you can install modkit some other way, and then add it to the path of your notebook or script. *NOTE: if you are creating the environment yourself, be sure to use python 3.10 or greater. Some dimelo package features require relatively new python releases.*
+Alternatively, you can install modkit into any conda environment you like. If you want to, you can install modkit some other way, and then add it to the path of your notebook or script. *NOTE: if you are creating the environment yourself, be sure to use python 3.10 or greater. Some dimelo-toolkit features require relatively new python releases.*
 
 ```
 conda install nanoporetech::modkit==0.2.4
@@ -125,7 +125,7 @@ sys.path.append('path_to_modkit_executable_directory')
 ```
 
 ## Developer Installation
-If you are planning on developing for the `dimelo` package, change the `pip install` command to install the package in "editable" mode, so that your code changes are reflected in your environment:
+If you are planning on developing for the `dimelo-toolkit` package, change the `pip install` command to install the package in "editable" mode, so that your code changes are reflected in your environment:
 ```
 pip install . -e
 ```
@@ -159,7 +159,7 @@ See the [tutorial](tutorial.ipynb) as a starting point.
 For local operation on Mac or Linux, you will already have cloned the repo to disk in the installation step. Activate your conda environment, make sure you have jupyter installed, and then launch a jupyter notebook server and navigate to `tutorial.ipynb`. You can also use other tools to open the jupyter notebook or you can simply reference it as an example.
 
 ```
-conda activate dimelo
+conda activate dimelo-toolkit
 jupyter notebook
 ```
 
@@ -224,7 +224,7 @@ You should expect to see some text outputs and a series of progress bars. Progre
 There should not be such issues for command line operation. See below an example of command line progress outputs: you should expect relatively fast pre-processing, 10-90 seconds, and then contig processing times depending heavily on the size of your `.bam` file and the extent of your `regions`.
 
 ```
-(dimelo_modkit_parsing) oberondixon-luinenburg@Oberons-MacBook-Pro package_test_notebooks % python dimelo_cmd.py
+(dimelo-toolkt) oberondixon-luinenburg@Oberons-MacBook-Pro package_test_notebooks % python dimelo_cmd.py
 modkit found with expected version 0.2.4
 No output directory provided, using input directory /Users/oberondixon-luinenburg/Documents/Ioannidis-Streets/dimelo_test_data/20230702_jm_lmnb1_acessibility_redux
 No specified number of cores requested. 8 available on machine, allocating all.
@@ -246,6 +246,7 @@ def plot_enrichment_profile(
     motifs: list[str],
     sample_names: list[str],
     window_size: int,
+    relative: bool = True,
     single_strand: bool = False,
     regions_5to3prime: bool = False,
     smooth_window: int | None = None,
@@ -268,6 +269,7 @@ def plot_enrichment_profile(
         mod_names: list of modifications to extract; expected to match mods available in the relevant mod_files
         sample_names: list of names to use for labeling traces in the output; legend entries
         window_size: half-size of the desired window to plot; how far the window stretches on either side of the center point
+        relative: True means x-axis is centered around region centers, False means x-axis is absolute genome positions. Must be True when plotting more than one region.
         single_strand: True means we only grab counts from reads from the same strand as
             the region of interest, False means we always grab both strands within the regions
         regions_5to3prime: True means negative strand regions get flipped, False means no flipping
@@ -440,6 +442,10 @@ def plot_read_browser(
     sort_by: str | list[str] = "shuffle",
     hover: bool = True,
     subset_parameters: dict | None = None,
+    span_full_window: bool = False,
+    width: int = 1,
+    size: int = 4,
+    colorscales: dict = utils.DEFAULT_COLORSCALES,
     **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
@@ -469,6 +475,10 @@ def plot_read_browser(
         hover: if False, disables display of information on mouse hover
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
             reads to be returned. If not None, at least one of n or frac must be provided.
+        span_full_window: if True, only plot reads that fully span the window defined by region_start-region_end
+        width: width of the read lines in the browser
+        size: size of the modification event markers in the browser
+        colorscales: dictionary mapping motif names to plotly colorscale specifications
 
     Returns:
         plotly Figure object containing the plot
@@ -747,6 +757,7 @@ def read_vectors_from_hdf5(
     quiet: bool = True,  # currently unused; change to default False when pbars are implemented
     cores: int | None = None,  # currently unused
     subset_parameters: dict | None = None,
+    span_full_window: bool = False,
 ) -> tuple[list[tuple], list[str], dict | None]:
     """
     User-facing function.
@@ -795,6 +806,7 @@ def read_vectors_from_hdf5(
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
             reads to be returned. If not None, at least one of n or frac must be provided. The array
             parameter should not be provided here.
+        span_full_window: If True, only load reads that fully span the window defined by region_start-region_end
 
     Returns:
         a list of tuples, each tuple containing all datasets corresponding to an individual read that

--- a/README.md
+++ b/README.md
@@ -224,9 +224,8 @@ You should expect to see some text outputs and a series of progress bars. Progre
 There should not be such issues for command line operation. See below an example of command line progress outputs: you should expect relatively fast pre-processing, 10-90 seconds, and then contig processing times depending heavily on the size of your `.bam` file and the extent of your `regions`.
 
 ```
-(dimelo-toolkt) oberondixon-luinenburg@Oberons-MacBook-Pro package_test_notebooks % python dimelo_cmd.py
+(dimelo-toolkit) % python dimelo_cmd.py
 modkit found with expected version 0.2.4
-No output directory provided, using input directory /Users/oberondixon-luinenburg/Documents/Ioannidis-Streets/dimelo_test_data/20230702_jm_lmnb1_acessibility_redux
 No specified number of cores requested. 8 available on machine, allocating all.
 Modification threshold of 0.9 will be treated as coming from range 0-1.
 ████████████████████| Preprocessing complete for motifs ['A,0'] in chm13.draft_v1.1.fasta:  100% | 00:30

--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -898,9 +898,7 @@ def read_vectors_from_hdf5(
         sorted_read_tuples = read_tuples_all
         for idx, is_reverse in reversed(sort_config):
             sorted_read_tuples = sorted(
-                sorted_read_tuples,
-                key=lambda x: x[idx],
-                reverse=is_reverse
+                sorted_read_tuples, key=lambda x: x[idx], reverse=is_reverse
             )
     else:
         sorted_read_tuples = read_tuples_all

--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -796,7 +796,7 @@ def read_vectors_from_hdf5(
             )
     #  We add region information (start, end, and strand; chromosome is already present!)
     # so that it is possible to sort by and process based on these
-    readwise_datasets += ["region_start", "region_end", "region_strand"]
+    readwise_datasets += ["region_start", "region_end", "region_strand", "read_length"]
 
     # This is sanitizing the dataset entries and adjusting prob values if needed
     if binarized:
@@ -812,6 +812,9 @@ def read_vectors_from_hdf5(
             )
             for tup in read_tuples_raw
         ]
+
+    read_start_idx = readwise_datasets.index("read_start")
+    read_end_idx = readwise_datasets.index("read_end")
 
     if calculate_mod_fractions:
         # Add the MOTIF_mod_fraction entries to the readwise_datasets list for future reference in sorting
@@ -832,8 +835,10 @@ def read_vectors_from_hdf5(
 
         read_tuples_all = []
         for read_tuple in read_tuples_processed:
+            read_length = read_tuple[read_end_idx] - read_tuple[read_start_idx]
             read_tuples_all.append(
                 tuple(val for val in read_tuple)
+                + (read_length,)
                 + tuple(
                     mod_frac
                     for mod_frac in mod_fractions_by_read_name_by_motif[
@@ -842,7 +847,10 @@ def read_vectors_from_hdf5(
                 )
             )
     else:
-        read_tuples_all = read_tuples_processed
+        read_tuples_all = []
+        for read_tuple in read_tuples_processed:
+            read_length = read_tuple[read_end_idx] - read_tuple[read_start_idx]
+            read_tuples_all.append(tuple(val for val in read_tuple) + (read_length,))
 
     ## Sort the reads
 

--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -854,29 +854,54 @@ def read_vectors_from_hdf5(
 
     ## Sort the reads
 
+    # Normalize sort_by to a list of tuples (field, order)
+    # Support formats:
+    #   - "field" or ["field1", "field2"] -> [("field1", "asc"), ("field2", "asc")]
+    #   - [("field1", "desc"), "field2"] -> [("field1", "desc"), ("field2", "asc")]
+
     # Enforce that sort_by is a list
     if not isinstance(sort_by, list):
         sort_by = [sort_by]
 
+    # Parse into (field, order) tuples
+    sort_by_normalized = []
+    for item in sort_by:
+        if isinstance(item, tuple):
+            field, order = item
+            if order not in ["asc", "desc"]:
+                raise ValueError(
+                    f"Sort order must be 'asc' or 'desc', got '{order}' for field '{field}'"
+                )
+            sort_by_normalized.append((field, order))
+        else:
+            # Default to ascending order
+            sort_by_normalized.append((item, "asc"))
+
     # If 'shuffle' appears anywhere in sort_by, we first shuffle the list
-    if "shuffle" in sort_by:
+    if any(field == "shuffle" for field, _ in sort_by_normalized):
         utils.rng.shuffle(read_tuples_all)
 
+    # Build sorting configuration
     try:
-        sort_by_indices = [
-            readwise_datasets.index(sort_item)
-            for sort_item in sort_by
-            if sort_item != "shuffle"
+        sort_config = [
+            (readwise_datasets.index(field), order == "desc")
+            for field, order in sort_by_normalized
+            if field != "shuffle"
         ]
     except ValueError as e:
         raise ValueError(
             f"Sorting error. {e}. Datasets include {readwise_datasets}. If you need mod fraction sorting make sure you are not setting calculate_read_fraction to False."
         ) from e
 
-    if len(sort_by_indices) > 0:
-        sorted_read_tuples = sorted(
-            read_tuples_all, key=lambda x: tuple(x[index] for index in sort_by_indices)
-        )
+    if len(sort_config) > 0:
+        # Use stable sort from right to left (reverse order of sort keys)
+        sorted_read_tuples = read_tuples_all
+        for idx, is_reverse in reversed(sort_config):
+            sorted_read_tuples = sorted(
+                sorted_read_tuples,
+                key=lambda x: x[idx],
+                reverse=is_reverse
+            )
     else:
         sorted_read_tuples = read_tuples_all
 

--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -629,6 +629,7 @@ def read_vectors_from_hdf5(
     quiet: bool = True,  # currently unused; change to default False when pbars are implemented
     cores: int | None = None,  # currently unused
     subset_parameters: dict | None = None,
+    span_full_window: bool = False,
 ) -> tuple[list[tuple], list[str], dict | None]:
     """
     User-facing function.
@@ -679,6 +680,7 @@ def read_vectors_from_hdf5(
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
             reads to be returned. If not None, at least one of n or frac must be provided. The array
             parameter should not be provided here.
+        span_full_window: If True, only load reads that fully span the window defined by region_start-region_end
 
     Returns:
         a list of tuples, each tuple containing all datasets corresponding to an individual read that
@@ -731,6 +733,8 @@ def read_vectors_from_hdf5(
                     relevant_read_indices = np.flatnonzero(
                         (read_ends > region_start)
                         & (read_starts < region_end)
+                        & (read_starts <= region_start if span_full_window else True)
+                        & (read_ends >= region_end if span_full_window else True)
                         & np.isin(read_motifs, motifs)
                         & (read_chromosomes == chrom)
                         & (

--- a/dimelo/parse_bam.py
+++ b/dimelo/parse_bam.py
@@ -968,13 +968,6 @@ def read_by_base_txt_to_hdf5(
                 canonical_base = fields[15]
                 prob = float(fields[10])
                 mod_code = fields[11]
-                read_len = int(fields[9])
-                ref_strand = fields[5]   
-                # TODO: verify that read position is in the right (ref) coordinate system 
-                if ref_strand == "+":
-                    pos_in_read_ref = int(fields[1])
-                elif ref_strand == "-":
-                    pos_in_read_ref = read_len - int(fields[1]) - 1
 
                 if read_name != fields[0]:
                     # Record the previous read details unless this is the first line
@@ -1047,6 +1040,13 @@ def read_by_base_txt_to_hdf5(
                     # Metadata
                     read_name = fields[0]
                     read_chrom = fields[3]
+                    read_len = int(fields[9])
+                    ref_strand = fields[5]   
+                    # TODO: verify that read position is in the right (ref) coordinate system 
+                    if ref_strand == "+":
+                        pos_in_read_ref = int(fields[1])
+                    elif ref_strand == "-":
+                        pos_in_read_ref = read_len - int(fields[1]) - 1
                     # Calculate read start (leftmost position on ref genome)
                     # TODO: logic can be replaced when we switch to true read start/end from modkit
                     read_start = pos_in_genome - pos_in_read_ref
@@ -1057,6 +1057,10 @@ def read_by_base_txt_to_hdf5(
                 # Adjust the read_end (rightmost position on ref genome) each time there's a new mod
                 # This will lead to the most accurate end positions for gapped reads
                 # TODO: logic can be replaced when we switch to true read start/end from modkit
+                if ref_strand == "+":
+                    pos_in_read_ref = int(fields[1])
+                elif ref_strand == "-":
+                    pos_in_read_ref = read_len - int(fields[1]) - 1
                 read_end = pos_in_genome + (read_len - pos_in_read_ref)
                 # Regardless of whether its a new read or not,
                 # add modification to vector if motif type is correct

--- a/dimelo/parse_bam.py
+++ b/dimelo/parse_bam.py
@@ -1041,8 +1041,8 @@ def read_by_base_txt_to_hdf5(
                     read_name = fields[0]
                     read_chrom = fields[3]
                     read_len = int(fields[9])
-                    ref_strand = fields[5]   
-                    # TODO: verify that read position is in the right (ref) coordinate system 
+                    ref_strand = fields[5]
+                    # TODO: verify that read position is in the right (ref) coordinate system
                     if ref_strand == "+":
                         pos_in_read_ref = int(fields[1])
                     elif ref_strand == "-":

--- a/dimelo/parse_bam.py
+++ b/dimelo/parse_bam.py
@@ -968,6 +968,13 @@ def read_by_base_txt_to_hdf5(
                 canonical_base = fields[15]
                 prob = float(fields[10])
                 mod_code = fields[11]
+                read_len = int(fields[9])
+                ref_strand = fields[5]   
+                # TODO: verify that read position is in the right (ref) coordinate system 
+                if ref_strand == "+":
+                    pos_in_read_ref = int(fields[1])
+                elif ref_strand == "-":
+                    pos_in_read_ref = read_len - int(fields[1]) - 1
 
                 if read_name != fields[0]:
                     # Record the previous read details unless this is the first line
@@ -1037,22 +1044,20 @@ def read_by_base_txt_to_hdf5(
                         read_counter += 1
 
                     ## Set up for next read
+                    # Metadata
                     read_name = fields[0]
                     read_chrom = fields[3]
-                    read_len = int(fields[9])
-                    ref_strand = fields[5]
-                    # TODO: verify that read position is in the right (ref) coordinate system
-                    if ref_strand == "+":
-                        pos_in_read_ref = int(fields[1])
-                    elif ref_strand == "-":
-                        pos_in_read_ref = read_len - int(fields[1]) - 1
-                    # Calculate read info
+                    # Calculate read start (leftmost position on ref genome)
+                    # TODO: logic can be replaced when we switch to true read start/end from modkit
                     read_start = pos_in_genome - pos_in_read_ref
-                    read_end = read_start + read_len
                     # Instantiate lists
                     mod_values_list = []
                     valid_coordinates_list = []
 
+                # Adjust the read_end (rightmost position on ref genome) each time there's a new mod
+                # This will lead to the most accurate end positions for gapped reads
+                # TODO: logic can be replaced when we switch to true read start/end from modkit
+                read_end = pos_in_genome + (read_len - pos_in_read_ref)
                 # Regardless of whether its a new read or not,
                 # add modification to vector if motif type is correct
                 # for the motif in question

--- a/dimelo/plot_enrichment_profile.py
+++ b/dimelo/plot_enrichment_profile.py
@@ -12,6 +12,7 @@ def plot_enrichment_profile(
     motifs: list[str],
     sample_names: list[str],
     window_size: int,
+    relative: bool = True,
     single_strand: bool = False,
     regions_5to3prime: bool = False,
     smooth_window: int | None = None,
@@ -39,6 +40,7 @@ def plot_enrichment_profile(
         mod_names: list of modifications to extract; expected to match mods available in the relevant mod_files
         sample_names: list of names to use for labeling traces in the output; legend entries
         window_size: half-size of the desired window to plot; how far the window stretches on either side of the center point
+        relative: True means x-axis is centered around region centers, False means x-axis is absolute genome positions
         single_strand: True means we only grab counts from reads from the same strand as
             the region of interest, False means we always grab both strands within the regions
         regions_5to3prime: True means negative strand regions get flipped, False means no flipping
@@ -65,8 +67,21 @@ def plot_enrichment_profile(
         cores=cores,
     )
 
+    if relative:
+        offset_center = 0
+    else:
+        regions_dict = utils.regions_dict_from_input(
+            regions_list[0],
+            window_size,
+        )
+        if len(regions_dict)==1 and len(list(regions_dict.values())[0])==1:
+            region_tuple = list(regions_dict.values())[0][0]
+            offset_center = (region_tuple[0] + region_tuple[1]) // 2
+        else:
+            raise ValueError("relative=False must be used when plotting more than one region.")
+
     axes = make_enrichment_profile_plot(
-        trace_vectors=trace_vectors, sample_names=sample_names, **kwargs
+        trace_vectors=trace_vectors, sample_names=sample_names, offset_center=offset_center, **kwargs
     )
     return axes
 
@@ -241,6 +256,7 @@ def get_enrichment_profiles(
 def make_enrichment_profile_plot(
     trace_vectors: list[np.ndarray],
     sample_names: list[str],
+    offset_center: int = 0,
     **kwargs,
 ) -> Axes:
     """
@@ -252,6 +268,7 @@ def make_enrichment_profile_plot(
     Args:
         trace_vectors: list of enrichment profile traces
         sample_names: list of names to use for labeling traces in the output; legend entries
+        offset_center: position offset to apply to x-axis (e.g., when plotting absolute genome positions)
         kwargs: other keyword parameters passed through to utils.line_plot
 
     Returns:
@@ -261,8 +278,8 @@ def make_enrichment_profile_plot(
         raise ValueError("Unequal number of inputs")
     axes = utils.line_plot(
         indep_vector=np.arange(
-            -len(trace_vectors[0]) // 2,
-            len(trace_vectors[0]) // 2 + len(trace_vectors[0]) % 2,
+            offset_center - len(trace_vectors[0]) // 2,
+            offset_center + len(trace_vectors[0]) // 2 + len(trace_vectors[0]) % 2,
         ),
         indep_name="pos",
         dep_vectors=trace_vectors,

--- a/dimelo/plot_enrichment_profile.py
+++ b/dimelo/plot_enrichment_profile.py
@@ -40,7 +40,7 @@ def plot_enrichment_profile(
         mod_names: list of modifications to extract; expected to match mods available in the relevant mod_files
         sample_names: list of names to use for labeling traces in the output; legend entries
         window_size: half-size of the desired window to plot; how far the window stretches on either side of the center point
-        relative: True means x-axis is centered around region centers, False means x-axis is absolute genome positions
+        relative: True means x-axis is centered around region centers, False means x-axis is absolute genome positions. Must be True when plotting more than one region.
         single_strand: True means we only grab counts from reads from the same strand as
             the region of interest, False means we always grab both strands within the regions
         regions_5to3prime: True means negative strand regions get flipped, False means no flipping

--- a/dimelo/plot_enrichment_profile.py
+++ b/dimelo/plot_enrichment_profile.py
@@ -74,14 +74,19 @@ def plot_enrichment_profile(
             regions_list[0],
             window_size,
         )
-        if len(regions_dict)==1 and len(list(regions_dict.values())[0])==1:
+        if len(regions_dict) == 1 and len(list(regions_dict.values())[0]) == 1:
             region_tuple = list(regions_dict.values())[0][0]
             offset_center = (region_tuple[0] + region_tuple[1]) // 2
         else:
-            raise ValueError("relative=False must be used when plotting more than one region.")
+            raise ValueError(
+                "relative=False must be used when plotting more than one region."
+            )
 
     axes = make_enrichment_profile_plot(
-        trace_vectors=trace_vectors, sample_names=sample_names, offset_center=offset_center, **kwargs
+        trace_vectors=trace_vectors,
+        sample_names=sample_names,
+        offset_center=offset_center,
+        **kwargs,
     )
     return axes
 

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -17,6 +17,9 @@ def plot_read_browser(
     hover: bool = True,
     subset_parameters: dict | None = None,
     span_full_window: bool = False,
+    width: int = 1,
+    size: int = 4,
+    colorscales: dict = utils.DEFAULT_COLORSCALES,
     **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
@@ -47,6 +50,9 @@ def plot_read_browser(
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
             reads to be returned. If not None, at least one of n or frac must be provided.
         span_full_window: if True, only plot reads that fully span the window defined by region_start-region_end
+        width: width of the read lines in the browser
+        size: size of the modification event markers in the browser
+        colorscales: dictionary mapping motif names to plotly colorscale specifications
 
     Returns:
         plotly Figure object containing the plot
@@ -173,6 +179,8 @@ def format_browser_data(
     # differences are caused by the assumptions made in parse_bam.extract h5 conversion
     # and don't matter for much but do cause the full duplicate check to leave duplicates,
     # which then cause non-unique indices for mapping in collapse mode
+    # The sorting below is just to make sure that when we drop duplicates, we keep
+    # the longest read extent for each read_name. It doesn't effect final figure sort order.
     read_extent_df = (
         read_df[["read_start", "read_end", "y_index", "read_name"]]
         .assign(read_length=lambda df: df.read_end - df.read_start)
@@ -325,6 +333,10 @@ def make_browser_figure(
         region_start: start position of the region being browsed
         region_end: end position of the region being browsed
         hover: if False, disables display of information on mouse hover
+        thresh: pass down threshold for color scaling of modification probabilities
+        width: width of the read lines in the browser
+        size: size of the modification event markers in the browser
+        colorscales: dictionary mapping motif names to plotly colorscale specifications
 
     TODO: Think about how this interfaces with different types of initial sorting...
     TODO: Make it so that this method does NOT modify the input dataframe

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -67,7 +67,7 @@ def plot_read_browser(
         motifs=motifs,
         single_strand=single_strand,
         sort_by=sort_by,
-        calculate_mod_fractions=False,
+        calculate_mod_fractions=True,
         subset_parameters=subset_parameters,
     )
 
@@ -107,6 +107,7 @@ def plot_read_browser(
         region_start=region_start,
         region_end=region_end,
         hover=hover,
+        thresh=thresh,
         **kwargs,
     )
 
@@ -294,6 +295,10 @@ def make_browser_figure(
     region_start: int,
     region_end: int,
     hover: bool = True,
+    thresh: int | float | None = None,
+    width: int = 1,
+    size: int = 4,
+    colorscales: dict = utils.DEFAULT_COLORSCALES,
     **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
@@ -341,7 +346,7 @@ def make_browser_figure(
                 x=[row.read_start, row.read_end],
                 y=[row.y_index, row.y_index],
                 mode="lines",
-                line=dict(width=1, color="lightgrey"),
+                line=dict(width=width, color="lightgrey"),
                 showlegend=False,
                 hoverinfo="text",
                 hovertext=row.read_name,
@@ -365,9 +370,11 @@ def make_browser_figure(
                     ]
                 ),
                 marker=dict(
-                    size=4,
+                    size=size,
                     color=motif_df["prob"],
-                    colorscale=utils.DEFAULT_COLORSCALES[motif],
+                    colorscale=colorscales[motif],
+                    cmin=thresh,
+                    cmax=1.0,
                     colorbar=dict(
                         title=dict(
                             text=f"{motif} probability",

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -120,6 +120,7 @@ def plot_read_browser(
         width=width,
         size=size,
         colorscales=colorscales,
+        **kwargs,
     )
 
     return fig
@@ -318,6 +319,7 @@ def make_browser_figure(
     width: int = 1,
     size: int = 4,
     colorscales: dict = utils.DEFAULT_COLORSCALES,
+    **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
     Make a browser figure, using the provided pre-processed data

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -16,6 +16,7 @@ def plot_read_browser(
     sort_by: str | list[str] = "shuffle",
     hover: bool = True,
     subset_parameters: dict | None = None,
+    span_full_window: bool = False,
     **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
@@ -45,6 +46,7 @@ def plot_read_browser(
         hover: if False, disables display of information on mouse hover
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
             reads to be returned. If not None, at least one of n or frac must be provided.
+        span_full_window: if True, only plot reads that fully span the window defined by region_start-region_end
 
     Returns:
         plotly Figure object containing the plot
@@ -69,6 +71,7 @@ def plot_read_browser(
         sort_by=sort_by,
         calculate_mod_fractions=True,
         subset_parameters=subset_parameters,
+        span_full_window=span_full_window,
     )
 
     mod_vector_index = entry_labels.index("mod_vector")

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -170,9 +170,13 @@ def format_browser_data(
     # differences are caused by the assumptions made in parse_bam.extract h5 conversion
     # and don't matter for much but do cause the full duplicate check to leave duplicates,
     # which then cause non-unique indices for mapping in collapse mode
-    read_extent_df = read_df[
-        ["read_start", "read_end", "y_index", "read_name"]
-    ].drop_duplicates(subset=["read_name"])
+    read_extent_df = (
+        read_df[["read_start", "read_end", "y_index", "read_name"]]
+        .assign(read_length=lambda df: df.read_end - df.read_start)
+        .sort_values("read_length", ascending=False) # TODO: logic can be removed once we reference true read lengths from modkit
+        .drop_duplicates(subset=["read_name"])
+        .drop(columns=["read_length"])
+    )
     # * represents the methylation events
     mod_event_df = (
         read_df[["y_index", "read_name", "motif", "pos_vector", "prob_vector"]]

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -176,7 +176,9 @@ def format_browser_data(
     read_extent_df = (
         read_df[["read_start", "read_end", "y_index", "read_name"]]
         .assign(read_length=lambda df: df.read_end - df.read_start)
-        .sort_values("read_length", ascending=False) # TODO: logic can be removed once we reference true read lengths from modkit
+        .sort_values(
+            "read_length", ascending=False
+        )  # TODO: logic can be removed once we reference true read lengths from modkit
         .drop_duplicates(subset=["read_name"])
         .drop(columns=["read_length"])
     )

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -117,7 +117,9 @@ def plot_read_browser(
         region_end=region_end,
         hover=hover,
         thresh=thresh,
-        **kwargs,
+        width=width,
+        size=size,
+        colorscales=colorscales,
     )
 
     return fig
@@ -316,7 +318,6 @@ def make_browser_figure(
     width: int = 1,
     size: int = 4,
     colorscales: dict = utils.DEFAULT_COLORSCALES,
-    **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
     Make a browser figure, using the provided pre-processed data

--- a/dimelo/test/dimelo_test.py
+++ b/dimelo/test/dimelo_test.py
@@ -62,12 +62,12 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                 # Read and compare file contents
                 file1_contents = f1.read()
                 file2_contents = f2.read()
-                assert file1_contents == file2_contents, (
-                    f"{test_case}: {pileup_bed} does not match {pileup_target}."
-                )
-            assert filecmp.cmp(regions_processed, regions_target, shallow=False), (
-                f"{test_case}: {regions_processed} does not match {regions_target}."
-            )
+                assert (
+                    file1_contents == file2_contents
+                ), f"{test_case}: {pileup_bed} does not match {pileup_target}."
+            assert filecmp.cmp(
+                regions_processed, regions_target, shallow=False
+            ), f"{test_case}: {regions_processed} does not match {regions_target}."
         else:
             print(f"{test_case} skipped for pileup.")
 
@@ -119,13 +119,13 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                             for target_item in target_dataset
                         ], f"{test_case}: {dataset} does not match."
                     else:
-                        assert test_dataset == target_dataset, (
-                            f"{test_case}: {dataset} does not match."
-                        )
+                        assert (
+                            test_dataset == target_dataset
+                        ), f"{test_case}: {dataset} does not match."
             # assert os.path.getsize(extract_h5) == os.path.getsize(extract_target), f"{test_case}: {extract_h5} does not match {extract_target}."
-            assert filecmp.cmp(regions_processed, regions_target, shallow=False), (
-                f"{test_case}: {regions_processed} does not match {regions_target}."
-            )
+            assert filecmp.cmp(
+                regions_processed, regions_target, shallow=False
+            ), f"{test_case}: {regions_processed} does not match {regions_target}."
         else:
             print(f"{test_case} skipped for extract.")
 
@@ -159,9 +159,9 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                     motif=motif,
                     **kwargs_counts_from_bedmethyl,
                 )
-                assert actual == expected, (
-                    f"{test_case}: Counts for motif {motif} are not equal"
-                )
+                assert (
+                    actual == expected
+                ), f"{test_case}: Counts for motif {motif} are not equal"
 
             kwargs_vectors_from_bedmethyl = filter_kwargs_for_func(
                 dm.load_processed.pileup_vectors_from_bedmethyl, kwargs
@@ -173,16 +173,16 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                     motif=motif,
                     **kwargs_vectors_from_bedmethyl,
                 )
-                assert len(expected_tuple) == len(actual_tuple), (
-                    f"{test_case}: Unexpected number of arrays returned for {motif}"
-                )
+                assert len(expected_tuple) == len(
+                    actual_tuple
+                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
 
                 for expected, actual in zip(expected_tuple, actual_tuple):
                     # TODO: The following was the original assertion error message, but it was not written in a functional way. Find a way to make it work as intended.
                     # assert np.array_equal(expected, actual), f"{test_case}: Arrays for motif {motif} are not equal: expected {value} but got {actual[key]}"
-                    assert np.array_equal(expected, actual), (
-                        f"{test_case}: Arrays for motif {motif} are not equal."
-                    )
+                    assert np.array_equal(
+                        expected, actual
+                    ), f"{test_case}: Arrays for motif {motif} are not equal."
         else:
             print(
                 f"{test_case} loading skipped for pileup_load_plot, continuing to plotting."
@@ -277,13 +277,13 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
 {value[np.where(value != actual[key])[0]]} vs {actual[key][np.where(value != actual[key])[0]]}.
                     """
                 elif isinstance(value, (str, int, bool)):
-                    assert actual[key] == expected[key], (
-                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
-                    )
+                    assert (
+                        actual[key] == expected[key]
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
                 else:
-                    assert np.isclose(actual[key], value, atol=1e-4), (
-                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
-                    )
+                    assert np.isclose(
+                        actual[key], value, atol=1e-4
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
         else:
             print("{test_case} skipped for read_vectors_from_hdf5.")
         kwargs_plot_reads_plot_reads = filter_kwargs_for_func(
@@ -301,9 +301,9 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
                     mod_file_name=extract_h5,
                     **kwargs_plot_reads_plot_reads,
                 )
-            assert "No threshold has been applied" in str(excinfo.value), (
-                f"{test_case}: unexpected exception {excinfo.value}"
-            )
+            assert "No threshold has been applied" in str(
+                excinfo.value
+            ), f"{test_case}: unexpected exception {excinfo.value}"
             # providing a threshold should be enough to run plot_reads.plot_reads without an error
             kwargs_plot_reads_plot_reads["thresh"] = 0.75
             ax = dm.plot_reads.plot_reads(
@@ -384,9 +384,9 @@ class TestLoadProcessed:
                     motif=motif,
                     **kwargs_counts_from_bedmethyl,
                 )
-                assert actual == expected, (
-                    f"{test_case}: Counts for motif {motif} are not equal"
-                )
+                assert (
+                    actual == expected
+                ), f"{test_case}: Counts for motif {motif} are not equal"
         else:
             print(f"{test_case} skipped for pileup_counts_from_bedmethyl.")
 
@@ -407,14 +407,14 @@ class TestLoadProcessed:
                     motif=motif,
                     **kwargs_vectors_from_bedmethyl,
                 )
-                assert len(expected_tuple) == len(actual_tuple), (
-                    f"{test_case}: Unexpected number of arrays returned for {motif}"
-                )
+                assert len(expected_tuple) == len(
+                    actual_tuple
+                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
 
                 for expected, actual in zip(expected_tuple, actual_tuple):
-                    assert np.array_equal(expected, actual), (
-                        f"{test_case}: Arrays for motif {motif} are not equal"
-                    )
+                    assert np.array_equal(
+                        expected, actual
+                    ), f"{test_case}: Arrays for motif {motif} are not equal"
         else:
             print(f"{test_case} skipped for pileup_vectors_from_bedmethyl.")
 
@@ -450,13 +450,13 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
 {value[np.where(value != actual[key])[0]]} vs {actual[key][np.where(value != actual[key])[0]]}.
                     """
                 elif isinstance(value, (str, int, bool)):
-                    assert actual[key] == expected[key], (
-                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
-                    )
+                    assert (
+                        actual[key] == expected[key]
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
                 else:
-                    assert np.isclose(actual[key], value, atol=1e-4), (
-                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
-                    )
+                    assert np.isclose(
+                        actual[key], value, atol=1e-4
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
         else:
             print("{test_case} skipped for read_vectors_from_hdf5.")
 
@@ -560,9 +560,9 @@ class TestPlotEnrichment:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_plot_enrichment,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_enrichment.plot_enrichment.")
 
@@ -589,9 +589,9 @@ class TestPlotEnrichment:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_by_regions,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_enrichment.by_regions.")
 
@@ -720,9 +720,9 @@ class TestPlotEnrichmentProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_profile_plot_enrichment_profile,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(
                 f"{test_case} skipped for plot_enrichment_profile.plot_enrichment_profile."
@@ -753,9 +753,9 @@ class TestPlotEnrichmentProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_profile_by_regions,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_enrichment_profile.by_regions.")
 
@@ -886,9 +886,9 @@ class TestPlotDepthProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_profile_plot_depth_profile,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_depth_profile.plot_depth_profile.")
 
@@ -917,9 +917,9 @@ class TestPlotDepthProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_profile_by_regions,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_depth_profile.by_regions.")
 
@@ -1046,9 +1046,9 @@ class TestPlotDepthHistogram:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_histogram_plot_depth_histogram,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_depth_histogram.plot_depth_histogram.")
 
@@ -1077,9 +1077,9 @@ class TestPlotDepthHistogram:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_histogram_by_regions,
                 )
-                assert isinstance(ax, Axes), (
-                    f"{test_case}: plotting failed for {motif}."
-                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
         else:
             print(f"{test_case} skipped for plot_depth_histogram.by_regions.")
 
@@ -1168,9 +1168,9 @@ class TestPlotReads:
                         mod_file_name=results["extract"][0],
                         **kwargs_plot_reads_plot_reads,
                     )
-                assert "No threshold has been applied" in str(excinfo.value), (
-                    f"{test_case}: unexpected exception {excinfo.value}"
-                )
+                assert "No threshold has been applied" in str(
+                    excinfo.value
+                ), f"{test_case}: unexpected exception {excinfo.value}"
                 # providing a threshold should be enough to run plot_reads.plot_reads without an error
                 kwargs_plot_reads_plot_reads["thresh"] = 0.75
                 ax = dm.plot_reads.plot_reads(
@@ -1208,9 +1208,9 @@ class TestPlotReadBrowser:
                     region=kwargs["regions"],
                     **kwargs_plot_read_browser,
                 )
-                assert isinstance(fig, plotly.graph_objs.Figure), (
-                    f"{test_case}: plotting failed."
-                )
+                assert isinstance(
+                    fig, plotly.graph_objs.Figure
+                ), f"{test_case}: plotting failed."
             else:
                 with pytest.raises(ValueError) as excinfo:
                     fig = dm.plot_read_browser.plot_read_browser(
@@ -1222,23 +1222,22 @@ class TestPlotReadBrowser:
                     isinstance(kwargs["regions"], list)
                     or Path(kwargs["regions"]).suffix == ".bed"
                 ) and kwargs["thresh"] is None:
-                    assert "Invalid region" in str(excinfo.value), (
-                        f"{test_case}: unexpected exception for no-threshold bad-region case {excinfo.value}"
-                    )
+                    assert (
+                        "Invalid region" in str(excinfo.value)
+                    ), f"{test_case}: unexpected exception for no-threshold bad-region case {excinfo.value}"
                 elif (
                     kwargs["thresh"] is not None
                     and not isinstance(kwargs["regions"], list)
                     and Path(kwargs["regions"]).suffix != ".bed"
                 ):
-                    assert "A threshold has been applied" in str(excinfo.value), (
-                        f"{test_case}: unexpected exception thresholded valid-region case {excinfo.value}"
-                    )
+                    assert (
+                        "A threshold has been applied" in str(excinfo.value)
+                    ), f"{test_case}: unexpected exception thresholded valid-region case {excinfo.value}"
                 else:
-                    assert "A threshold has been applied" in str(
-                        excinfo.value
-                    ) or "Invalid region" in str(excinfo.value), (
-                        f"{test_case}: unexpected exception thresholded bad-region case {excinfo.value}"
-                    )
+                    assert (
+                        "A threshold has been applied" in str(excinfo.value)
+                        or "Invalid region" in str(excinfo.value)
+                    ), f"{test_case}: unexpected exception thresholded bad-region case {excinfo.value}"
 
         else:
             print(f"{test_case} skipped for test_unit__plot_read_browser")

--- a/dimelo/test/dimelo_test.py
+++ b/dimelo/test/dimelo_test.py
@@ -60,12 +60,12 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                 # Read and compare file contents
                 file1_contents = f1.read()
                 file2_contents = f2.read()
-                assert (
-                    file1_contents == file2_contents
-                ), f"{test_case}: {pileup_bed} does not match {pileup_target}."
-            assert filecmp.cmp(
-                regions_processed, regions_target, shallow=False
-            ), f"{test_case}: {regions_processed} does not match {regions_target}."
+                assert file1_contents == file2_contents, (
+                    f"{test_case}: {pileup_bed} does not match {pileup_target}."
+                )
+            assert filecmp.cmp(regions_processed, regions_target, shallow=False), (
+                f"{test_case}: {regions_processed} does not match {regions_target}."
+            )
         else:
             print(f"{test_case} skipped for pileup.")
 
@@ -117,13 +117,13 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                             for target_item in target_dataset
                         ], f"{test_case}: {dataset} does not match."
                     else:
-                        assert (
-                            test_dataset == target_dataset
-                        ), f"{test_case}: {dataset} does not match."
+                        assert test_dataset == target_dataset, (
+                            f"{test_case}: {dataset} does not match."
+                        )
             # assert os.path.getsize(extract_h5) == os.path.getsize(extract_target), f"{test_case}: {extract_h5} does not match {extract_target}."
-            assert filecmp.cmp(
-                regions_processed, regions_target, shallow=False
-            ), f"{test_case}: {regions_processed} does not match {regions_target}."
+            assert filecmp.cmp(regions_processed, regions_target, shallow=False), (
+                f"{test_case}: {regions_processed} does not match {regions_target}."
+            )
         else:
             print(f"{test_case} skipped for extract.")
 
@@ -157,9 +157,9 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                     motif=motif,
                     **kwargs_counts_from_bedmethyl,
                 )
-                assert (
-                    actual == expected
-                ), f"{test_case}: Counts for motif {motif} are not equal"
+                assert actual == expected, (
+                    f"{test_case}: Counts for motif {motif} are not equal"
+                )
 
             kwargs_vectors_from_bedmethyl = filter_kwargs_for_func(
                 dm.load_processed.pileup_vectors_from_bedmethyl, kwargs
@@ -171,16 +171,16 @@ class TestParseToPlot(DiMeLoParsingTestCase):
                     motif=motif,
                     **kwargs_vectors_from_bedmethyl,
                 )
-                assert len(expected_tuple) == len(
-                    actual_tuple
-                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
+                assert len(expected_tuple) == len(actual_tuple), (
+                    f"{test_case}: Unexpected number of arrays returned for {motif}"
+                )
 
                 for expected, actual in zip(expected_tuple, actual_tuple):
                     # TODO: The following was the original assertion error message, but it was not written in a functional way. Find a way to make it work as intended.
                     # assert np.array_equal(expected, actual), f"{test_case}: Arrays for motif {motif} are not equal: expected {value} but got {actual[key]}"
-                    assert np.array_equal(
-                        expected, actual
-                    ), f"{test_case}: Arrays for motif {motif} are not equal."
+                    assert np.array_equal(expected, actual), (
+                        f"{test_case}: Arrays for motif {motif} are not equal."
+                    )
         else:
             print(
                 f"{test_case} loading skipped for pileup_load_plot, continuing to plotting."
@@ -275,13 +275,13 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
 {value[np.where(value != actual[key])[0]]} vs {actual[key][np.where(value != actual[key])[0]]}.
                     """
                 elif isinstance(value, (str, int, bool)):
-                    assert (
-                        actual[key] == expected[key]
-                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    assert actual[key] == expected[key], (
+                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    )
                 else:
-                    assert np.isclose(
-                        actual[key], value, atol=1e-4
-                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    assert np.isclose(actual[key], value, atol=1e-4), (
+                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    )
         else:
             print("{test_case} skipped for read_vectors_from_hdf5.")
         kwargs_plot_reads_plot_reads = filter_kwargs_for_func(
@@ -299,9 +299,9 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
                     mod_file_name=extract_h5,
                     **kwargs_plot_reads_plot_reads,
                 )
-            assert "No threshold has been applied" in str(
-                excinfo.value
-            ), f"{test_case}: unexpected exception {excinfo.value}"
+            assert "No threshold has been applied" in str(excinfo.value), (
+                f"{test_case}: unexpected exception {excinfo.value}"
+            )
             # providing a threshold should be enough to run plot_reads.plot_reads without an error
             kwargs_plot_reads_plot_reads["thresh"] = 0.75
             ax = dm.plot_reads.plot_reads(
@@ -382,9 +382,9 @@ class TestLoadProcessed:
                     motif=motif,
                     **kwargs_counts_from_bedmethyl,
                 )
-                assert (
-                    actual == expected
-                ), f"{test_case}: Counts for motif {motif} are not equal"
+                assert actual == expected, (
+                    f"{test_case}: Counts for motif {motif} are not equal"
+                )
         else:
             print(f"{test_case} skipped for pileup_counts_from_bedmethyl.")
 
@@ -405,14 +405,14 @@ class TestLoadProcessed:
                     motif=motif,
                     **kwargs_vectors_from_bedmethyl,
                 )
-                assert len(expected_tuple) == len(
-                    actual_tuple
-                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
+                assert len(expected_tuple) == len(actual_tuple), (
+                    f"{test_case}: Unexpected number of arrays returned for {motif}"
+                )
 
                 for expected, actual in zip(expected_tuple, actual_tuple):
-                    assert np.array_equal(
-                        expected, actual
-                    ), f"{test_case}: Arrays for motif {motif} are not equal"
+                    assert np.array_equal(expected, actual), (
+                        f"{test_case}: Arrays for motif {motif} are not equal"
+                    )
         else:
             print(f"{test_case} skipped for pileup_vectors_from_bedmethyl.")
 
@@ -448,13 +448,13 @@ mismatch values expected {value[np.where(value != actual[key])]} vs actual {actu
 {value[np.where(value != actual[key])[0]]} vs {actual[key][np.where(value != actual[key])[0]]}.
                     """
                 elif isinstance(value, (str, int, bool)):
-                    assert (
-                        actual[key] == expected[key]
-                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    assert actual[key] == expected[key], (
+                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    )
                 else:
-                    assert np.isclose(
-                        actual[key], value, atol=1e-4
-                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    assert np.isclose(actual[key], value, atol=1e-4), (
+                        f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                    )
         else:
             print("{test_case} skipped for read_vectors_from_hdf5.")
 
@@ -558,9 +558,9 @@ class TestPlotEnrichment:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_plot_enrichment,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_enrichment.plot_enrichment.")
 
@@ -587,9 +587,9 @@ class TestPlotEnrichment:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_by_regions,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_enrichment.by_regions.")
 
@@ -718,9 +718,9 @@ class TestPlotEnrichmentProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_profile_plot_enrichment_profile,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(
                 f"{test_case} skipped for plot_enrichment_profile.plot_enrichment_profile."
@@ -751,9 +751,9 @@ class TestPlotEnrichmentProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_enrichment_profile_by_regions,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_enrichment_profile.by_regions.")
 
@@ -884,9 +884,9 @@ class TestPlotDepthProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_profile_plot_depth_profile,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_depth_profile.plot_depth_profile.")
 
@@ -915,9 +915,9 @@ class TestPlotDepthProfile:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_profile_by_regions,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_depth_profile.by_regions.")
 
@@ -1044,9 +1044,9 @@ class TestPlotDepthHistogram:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_histogram_plot_depth_histogram,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_depth_histogram.plot_depth_histogram.")
 
@@ -1075,9 +1075,9 @@ class TestPlotDepthHistogram:
                     sample_names=["label" for _ in regions_list],
                     **kwargs_plot_depth_histogram_by_regions,
                 )
-                assert isinstance(
-                    ax, Axes
-                ), f"{test_case}: plotting failed for {motif}."
+                assert isinstance(ax, Axes), (
+                    f"{test_case}: plotting failed for {motif}."
+                )
         else:
             print(f"{test_case} skipped for plot_depth_histogram.by_regions.")
 
@@ -1166,9 +1166,9 @@ class TestPlotReads:
                         mod_file_name=results["extract"][0],
                         **kwargs_plot_reads_plot_reads,
                     )
-                assert "No threshold has been applied" in str(
-                    excinfo.value
-                ), f"{test_case}: unexpected exception {excinfo.value}"
+                assert "No threshold has been applied" in str(excinfo.value), (
+                    f"{test_case}: unexpected exception {excinfo.value}"
+                )
                 # providing a threshold should be enough to run plot_reads.plot_reads without an error
                 kwargs_plot_reads_plot_reads["thresh"] = 0.75
                 ax = dm.plot_reads.plot_reads(
@@ -1206,9 +1206,9 @@ class TestPlotReadBrowser:
                     region=kwargs["regions"],
                     **kwargs_plot_read_browser,
                 )
-                assert isinstance(
-                    fig, plotly.graph_objs.Figure
-                ), f"{test_case}: plotting failed."
+                assert isinstance(fig, plotly.graph_objs.Figure), (
+                    f"{test_case}: plotting failed."
+                )
             else:
                 with pytest.raises(ValueError) as excinfo:
                     fig = dm.plot_read_browser.plot_read_browser(
@@ -1220,22 +1220,23 @@ class TestPlotReadBrowser:
                     isinstance(kwargs["regions"], list)
                     or Path(kwargs["regions"]).suffix == ".bed"
                 ) and kwargs["thresh"] is None:
-                    assert (
-                        "Invalid region" in str(excinfo.value)
-                    ), f"{test_case}: unexpected exception for no-threshold bad-region case {excinfo.value}"
+                    assert "Invalid region" in str(excinfo.value), (
+                        f"{test_case}: unexpected exception for no-threshold bad-region case {excinfo.value}"
+                    )
                 elif (
                     kwargs["thresh"] is not None
                     and not isinstance(kwargs["regions"], list)
                     and Path(kwargs["regions"]).suffix != ".bed"
                 ):
-                    assert (
-                        "A threshold has been applied" in str(excinfo.value)
-                    ), f"{test_case}: unexpected exception thresholded valid-region case {excinfo.value}"
+                    assert "A threshold has been applied" in str(excinfo.value), (
+                        f"{test_case}: unexpected exception thresholded valid-region case {excinfo.value}"
+                    )
                 else:
-                    assert (
-                        "A threshold has been applied" in str(excinfo.value)
-                        or "Invalid region" in str(excinfo.value)
-                    ), f"{test_case}: unexpected exception thresholded bad-region case {excinfo.value}"
+                    assert "A threshold has been applied" in str(
+                        excinfo.value
+                    ) or "Invalid region" in str(excinfo.value), (
+                        f"{test_case}: unexpected exception thresholded bad-region case {excinfo.value}"
+                    )
 
         else:
             print(f"{test_case} skipped for test_unit__plot_read_browser")

--- a/dimelo/test/dimelo_test.py
+++ b/dimelo/test/dimelo_test.py
@@ -51,8 +51,10 @@ class TestParseToPlot(DiMeLoParsingTestCase):
         pileup_target, regions_target = results["pileup"]
 
         if pileup_target is not None and regions_target is not None:
-            # This is necessary because the gzipped files are different on mac vs linux, but the contents should be identical (and are, so far)
-            # Not sure why the compression ratio is better on Linux when both are using pysam.tabix_compress with pysam 0.22.0 and zlib 1.2.13 but whatcha gonna do
+            # This is necessary because the gzipped files are different on mac vs linux,
+            # but the contents should be identical (and are, so far)
+            # Not sure why the compression ratio is better on Linux when both are using
+            # pysam.tabix_compress with pysam 0.22.0 and zlib 1.2.13 but whatcha gonna do
             with (
                 gzip.open(pileup_bed, "rt") as f1,
                 gzip.open(pileup_target, "rt") as f2,

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -27,7 +27,9 @@ DEFAULT_COLORS.update(
         "CG,0": "orange",
         "CG,0,m": "yellow",
         "CG,0,h": "red",
-        "GCH,1": "purple",
+        "HCG,1":"orange",
+        "WCG,1":"red",
+        "GCH,1": "green",
     }
 )
 # Default colorscales for plotly; based off of DEFAULT_COLORS

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -27,8 +27,8 @@ DEFAULT_COLORS.update(
         "CG,0": "orange",
         "CG,0,m": "yellow",
         "CG,0,h": "red",
-        "HCG,1":"orange",
-        "WCG,1":"red",
+        "HCG,1": "orange",
+        "WCG,1": "red",
         "GCH,1": "green",
     }
 )

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -75,7 +75,7 @@ class ParsedMotif:
             if self.modified_pos >= len(self.motif_seq):
                 raise ValueError(f"Motif {motif_string} has an out-of-range mod index.")
             self.modified_base = self.motif_seq[self.modified_pos]
-            self.mod_codes = set(parts[2])
+            self.mod_codes = set([parts[2]])
         else:
             # Motifs need both a sequence and an index, separated by a comma
             raise ValueError(

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: dimelo
+name: dimelo-toolkit
 channels:
   - conda-forge
   - nanoporetech


### PR DESCRIPTION
Miscellaneous updates in preparation for journal submission. Existing pytest tests all currently pass without changing any pass/fail criteria.

`environment.yml`: change environment name to `dimelo-toolkit`

`load_processed.read_vectors_from_hdf5`: updates to support new single read browser plots that better show data

- Added `span_full_window` option. If true, only reads that start before the region_start and end before the region_end are returned, i.e. they must be at least as long as the region. If false, maintain old behavior: all reads that end after the region_start and start before region_end are returned. 
- Added `read_length` field for sorting
- Added sorting in `asc` vs `desc` order for each of the sequential sorting operations

`parse_bam::read_by_base_txt_to_hdf5`: updates to support single reads with long gaps, e.g. RNA with splicing

- When finding reads in the .txt file, instead of calculating read end position once when the read is first encountered (based on current position in genome + current position in read + read length), the read end position is re-calculated each time a new base is encountered for that read. Because the txt is ordered ascending along the genome, the last base encountered for a read will be the one closest to the end of that read. With e.g. megalodon bam files this always gives identical results to the old read end calculation method.

The new method still misses any read gaps that show up after the last potential modification site: this information will only be available with the modkit upgrade described here: https://github.com/nanoporetech/modkit/issues/270 

`plot_enrichment_profile::plot_enrichment_profile`: update to support profile plots with absolute rather than relative coordinates

- `plot_enrichment_profile` methods can take in `relative` flag; True means x-axis is centered around region centers, False means x-axis is absolute genome positions
- `make_enrichment_profile_plot` can take `offset_center`, which gives a position offset to apply to the plot x-axis (e.g., when plotting absolute genome positions)

`plot_read_browser::plot_read_browser`: update to allow new plot customizations and make it work a bit better with gapped read e.g. RNA

- markers/lines/color palette settings
- pass down the span_full_window parameter to the loader
- read_extent_df now keeps the longest version of each read name, because until we have the new modkit version there are different entries for each mod type for each read, and those each have lengths calculated by the method above which are not guaranteed to be the same between mods

`utils::DEFAULT_COLORS`: add new ones

`utils::ParsedMotif`: fix mod code handling for mod codes more than one character long: the set() function if given a string will give a set of the *characters in the string* whereas we want in this case a set *of string*, e.g. "17802" for pseudouridine