### PR TITLE
deep copy in make_browser_figure

### DIFF
--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -342,13 +342,14 @@ def make_browser_figure(
         colorscales: dictionary mapping motif names to plotly colorscale specifications
 
     TODO: Think about how this interfaces with different types of initial sorting...
-    TODO: Make it so that this method does NOT modify the input dataframe
     TODO: Should this method do the collapsing, or should this method require collapsing outside?
     """
     if collapse:
         index_map = collapse_rows(read_extent_df, **kwargs)
-        read_extent_df["y_index"] = read_extent_df["y_index"].map(index_map)
-        mod_event_df["y_index"] = mod_event_df["y_index"].map(index_map)
+        read_extent_df.copy()
+        # NOTE: `DataFrame.assign` performs a deep copy, preventing the modification of the array that is passed in. For very large datasets, this duplication may cause memory issues.
+        read_extent_df = read_extent_df.assign(y_index=read_extent_df["y_index"].map(index_map))
+        mod_event_df = mod_event_df.assign(y_index=mod_event_df["y_index"].map(index_map))
 
     # Build final figure
     # TODO: Enable setting some relevant parameters

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -346,7 +346,6 @@ def make_browser_figure(
     """
     if collapse:
         index_map = collapse_rows(read_extent_df, **kwargs)
-        read_extent_df.copy()
         # NOTE: `DataFrame.assign` performs a deep copy, preventing the modification of the array that is passed in. For very large datasets, this duplication may cause memory issues.
         read_extent_df = read_extent_df.assign(
             y_index=read_extent_df["y_index"].map(index_map)

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -348,8 +348,12 @@ def make_browser_figure(
         index_map = collapse_rows(read_extent_df, **kwargs)
         read_extent_df.copy()
         # NOTE: `DataFrame.assign` performs a deep copy, preventing the modification of the array that is passed in. For very large datasets, this duplication may cause memory issues.
-        read_extent_df = read_extent_df.assign(y_index=read_extent_df["y_index"].map(index_map))
-        mod_event_df = mod_event_df.assign(y_index=mod_event_df["y_index"].map(index_map))
+        read_extent_df = read_extent_df.assign(
+            y_index=read_extent_df["y_index"].map(index_map)
+        )
+        mod_event_df = mod_event_df.assign(
+            y_index=mod_event_df["y_index"].map(index_map)
+        )
 
     # Build final figure
     # TODO: Enable setting some relevant parameters


### PR DESCRIPTION
Avoid modifying the input dataframe in `make_browser_figure`, to avoid a bug where it was impossible to rerun the browser figure with collapsing reads until the input dataframe `y_index` column was reset to be non-unique.

The current (very simple) implementation of this fix relies on a deep copy operation, meaning that for very large datasets this may cause memory issues. I do not foresee this being the bottleneck for read browsing; by the time this becomes an issue the browser itself may be completely inoperable. However, I am leaving the space for a different fix to be implemented if this is a problem.

Addressing this issue in some other way will require a rewrite of the plotting logic, as the column in question is referenced inside of a different groupby operation.